### PR TITLE
Add await async capabilities to network layer

### DIFF
--- a/SwiftUI/OrdiCore/Sources/Business/Network/NetworkProtocol.swift
+++ b/SwiftUI/OrdiCore/Sources/Business/Network/NetworkProtocol.swift
@@ -24,3 +24,7 @@ public protocol NetworkProtocol {
     func call<T: Codable, U: Endpoint>(api: U, model: T.Type) -> RSResponse<T>
     func upload<T: Codable, U: Endpoint>(api: U, model: T.Type) -> RSResponseWithProgress<T>
 }
+
+public protocol AwaitableNetworkProtocol {
+    func call<T: Codable>(api: some Endpoint, model: T.Type) async throws -> T
+}


### PR DESCRIPTION
# Description
Mainly targeted to understand await & async, plus the difference between `some`, `any` & Generics by knowing when to use each, this PR may be broken down into smaller pieces to provide better visibility on how the new pieces of Swift 5.7 work together

# Features
1. [ ] await async
2. [ ] some
3. [ ] any